### PR TITLE
Add ment about no delete and edit button in post modal one day after

### DIFF
--- a/src/components/challengedetail/PostList.js
+++ b/src/components/challengedetail/PostList.js
@@ -179,9 +179,30 @@ const PostList = (props) => {
                   </Button>
                 </MeBtn>
               ) : null}
+              {!list[clicked]?.postingModifyOk &&
+              list[clicked]?.memberId === user_info.memberId ? (
+                <Button
+                  borderRadius="16px"
+                  width="100%"
+                  height="5.93vh"
+                  border="white"
+                  bg="white"
+                  margin="4.07vh 0 0 0"
+                  color="mainGreen"
+                >
+                  인증샷을 올린 다음 날에는 수정과 삭제가 어려워요!
+                </Button>
+              ) : null}
               {challengeStatus === 2 &&
               list[clicked]?.memberId !== user_info.memberId ? (
-                <button onClick={check}>인증 확인</button>
+                <Button
+                  width="100%"
+                  height="5.93vh"
+                  margin="4.07vh 0 0 0"
+                  _onClick={check}
+                >
+                  인증 확인
+                </Button>
               ) : null}
             </div>
           </>

--- a/src/elements/Button.js
+++ b/src/elements/Button.js
@@ -76,6 +76,6 @@ const ElButton = styled.button`
   font-weight: bold;
   ${(props) =>
     props.chat
-      ? `position: absolute; top: 88.88vh; right: 16.67vw; box-shadow: rgba(0,219,154,0.2) 0px 8px 24px;`
+      ? `position: fixed; bottom: 14.81vh; right: 16.67vw; box-shadow: rgba(0,219,154,0.2) 0px 8px 24px;`
       : null}
 `;


### PR DESCRIPTION
- 채팅 버튼 position: fixed 로 수정
- 로그인한 유저가 전날에 올린 인증샷 다시 봤을 때 수정 / 삭제 버튼 없으므로 `인증샷 게시물을 올린 다음날에는 수정 / 삭제 어려워요!` 같은 멘트 버튼 자리에 추가!